### PR TITLE
Hot Module Reloading

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -128,6 +128,7 @@ module.exports = class extends Generator {
         'mini-css-extract-plugin',
         'null-loader',
         'webpack-node-externals',
+        'webpack-dev-server',
       ],
       {
         'save-dev': true,

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -43,7 +43,7 @@ module.exports = class extends Generator {
 
       // Server
       'src/server/api/index.ts',
-      'src/server/index.html',
+      'src/server/index.ejs',
       'src/server/index.tsx',
       'src/server/page.ts',
       'src/server/registry.ts',
@@ -101,6 +101,7 @@ module.exports = class extends Generator {
       'express',
       'flux-standard-functions',
       'ts-registry',
+      'ejs',
     ]);
     this.npmInstall(
       [
@@ -110,6 +111,7 @@ module.exports = class extends Generator {
         '@types/react-router',
         '@types/react-router-dom',
         '@types/express',
+        '@types/ejs',
         'webpack-cli',
 
         'less',

--- a/src/app/templates/Dockerfile.template
+++ b/src/app/templates/Dockerfile.template
@@ -5,7 +5,7 @@ COPY package.json package-lock.json ./
 RUN npm ci
 
 COPY . .
-RUN npm run build:prod
+RUN npm run build
 
 FROM node:12-alpine
 WORKDIR /app
@@ -16,4 +16,4 @@ RUN npm ci --production
 COPY --from=builder /app/.compiled ./.compiled
 
 EXPOSE 3000
-ENTRYPOINT ["npm", "start"]
+ENTRYPOINT ["npm", "run", "server"]

--- a/src/app/templates/package.json.template
+++ b/src/app/templates/package.json.template
@@ -4,11 +4,13 @@
   "description": "<%= description %>",
   "main": "./.compiled/server/index.js",
   "scripts": {
-    "prebuild": "npm run lint && rm -rf .compiled/*",
-    "build": "webpack --config ./webpack.dev.js",
-    "build:prod": "webpack --config ./webpack.prod.js",
+    "clean": "npm run lint && rm -rf .compiled/*",
+    "prebuild": "npm run clean",
+    "build": "webpack --config ./webpack.prod.js",
+    "server": "node ./.compiled/server/server.js",
     "lint": "tslint -c tslint.json -e 'node_modules/**/*' '**/*.ts'",
-    "start": "node ./.compiled/server/server.js",
+    "prestart": "npm run clean && tsc",
+    "start": "webpack-dev-server --config webpack.dev.js",
     "test": "NODE_ENV=test nyc mocha --require source-map-support/register --require ts-node/register --recursive './src/**/*.tests.ts'"
   },
   "keywords": [],

--- a/src/app/templates/src/server/index.ejs.template
+++ b/src/app/templates/src/server/index.ejs.template
@@ -4,6 +4,9 @@
     <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
   </head>
   <body>
-    Hello World!
+    <div id="app"><$ if(html) { $><$- html $><$ } $></div>
+    <script>
+      window.$REDUX_STATE = '<$- state $>';
+    </script>
   </body>
 </html>

--- a/src/app/templates/src/server/page.ts.template
+++ b/src/app/templates/src/server/page.ts.template
@@ -1,29 +1,18 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { render as renderTemplate } from 'ejs';
 
 import { ApplicationState } from '../common/entities';
 
-const files = fs.readdirSync(path.join(process.cwd(), '.compiled', 'dist'));
-const main = files.find(file => file.startsWith('main.'));
-const vendor = files.find(file => file.startsWith('vendor.'));
-const style = files.find(file => file.endsWith('.css'));
+const template = readFileSync(
+  join(process.cwd(), '.compiled', 'dist', 'index.ejs'),
+).toString();
 
 export function render(state: ApplicationState, html: string) {
-  return `
-<!doctype html>
-<html lang="utf-8">
-  <head>
-  <title>React App</title>
-  <link rel="stylesheet" type="text/css" href="/dist/${style}">
-  </head>
-  <body>
-  <div id="app">${html}</div>
-  <script>
-    window.$REDUX_STATE = ${JSON.stringify(state)};
-  </script>
-  <script src="/dist/${vendor}"></script>
-  <script src="/dist/${main}"></script>
-  </body>
-</html>
-`;
+  return renderTemplate(
+    template,
+    { state: JSON.stringify(state), html },
+    { delimiter: '$' },
+  );
 }

--- a/src/app/templates/src/server/page.ts.template
+++ b/src/app/templates/src/server/page.ts.template
@@ -6,7 +6,7 @@ import { render as renderTemplate } from 'ejs';
 import { ApplicationState } from '../common/entities';
 
 const template = readFileSync(
-  join(process.cwd(), '.compiled', 'dist', 'index.ejs'),
+  join(process.cwd(), '.compiled', 'dist', 'index.html'),
 ).toString();
 
 export function render(state: ApplicationState, html: string) {

--- a/src/app/templates/tsconfig.json.template
+++ b/src/app/templates/tsconfig.json.template
@@ -3,13 +3,13 @@
     "lib": ["es2015", "dom"],
     "module": "commonjs",
     "noImplicitReturns": true,
-    "outDir": ".compiled",
+    "outDir": ".compiled/api",
     "sourceMap": true,
     "target": "es5",
     "jsx": "react",
     "esModuleInterop": true,
     "moduleResolution": "node"
   },
-  "include": ["./src/**/*.ts", "./src/**/*.tsx"],
+  "include": ["./src/server/api/index.ts"],
   "exclude": ["./src/client/"]
 }

--- a/src/app/templates/webpack.common.js.template
+++ b/src/app/templates/webpack.common.js.template
@@ -33,7 +33,7 @@ const client = {
   plugins: [
     new HtmlWebpackPlugin({
       template: './src/server/index.ejs',
-      filename: 'index.ejs',
+      filename: 'index.html',
     }),
   ],
   resolve: {

--- a/src/app/templates/webpack.common.js.template
+++ b/src/app/templates/webpack.common.js.template
@@ -28,10 +28,12 @@ const client = {
   },
   output: {
     path: path.resolve(__dirname, '.compiled', 'dist'),
+    publicPath: '/dist',
   },
   plugins: [
     new HtmlWebpackPlugin({
-      template: './src/server/index.html',
+      template: './src/server/index.ejs',
+      filename: 'index.ejs',
     }),
   ],
   resolve: {

--- a/src/app/templates/webpack.dev.js.template
+++ b/src/app/templates/webpack.dev.js.template
@@ -5,37 +5,41 @@ const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 const [client, server] = require('./webpack.common.js');
+const api = require('./.compiled/api');
 
-module.exports = [
-  merge(client, {
-    mode: 'development',
-    devServer: {
-      contentBase: path.join(__dirname, '.compiled', 'dist'),
-      port: 9000,
-      hot: true,
+module.exports = merge(client, {
+  mode: 'development',
+  devServer: {
+    contentBase: path.join(__dirname, '.compiled', 'dist'),
+    port: 9000,
+    hot: true,
+    historyApiFallback: {
+      rewrites: [{ from: /.*/, to: '/dist/index.html' }],
     },
-    devtool: 'inline-source-map',
-    module: {
-      rules: [
-        {
-          test: /\.less$/,
-          use: [
-            'css-hot-loader',
-            MiniCssExtractPlugin.loader,
-            'css-loader',
-            'less-loader',
-          ],
-          exclude: /node_modules/,
-        },
-      ],
+    before: function(app) {
+      app.use('/api', api.app);
     },
-    plugins: [
-      new webpack.HotModuleReplacementPlugin(),
-      new MiniCssExtractPlugin({ filename: '[name].css' }),
+  },
+  devtool: 'inline-source-map',
+  module: {
+    rules: [
+      {
+        test: /\.less$/,
+        use: [
+          'css-hot-loader',
+          MiniCssExtractPlugin.loader,
+          'css-loader',
+          'less-loader',
+        ],
+        exclude: /node_modules/,
+      },
     ],
-    output: {
-      filename: '[name].js',
-    },
-  }),
-  merge(server, { mode: 'development' }),
-];
+  },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    new MiniCssExtractPlugin({ filename: '[name].css' }),
+  ],
+  output: {
+    filename: '[name].js',
+  },
+});

--- a/src/app/templates/webpack.dev.js.template
+++ b/src/app/templates/webpack.dev.js.template
@@ -37,5 +37,5 @@ module.exports = [
       filename: '[name].js',
     },
   }),
-  server,
+  merge(server, { mode: 'development' }),
 ];

--- a/src/app/templates/webpack.prod.js.template
+++ b/src/app/templates/webpack.prod.js.template
@@ -24,5 +24,5 @@ module.exports = [
       filename: '[name].[contenthash].js',
     },
   }),
-  server,
+  merge(server, { mode: 'production' }),
 ];


### PR DESCRIPTION
Script changes:
* `npm run build` is now prod-only
* `npm run server` runs the server
* `npm start` runs the app client-side-only (with HMR) with API support

Webpack changes:
* The `api` express app is added as a `before` for the dev-server. This allows the dev-server to also respond to API requests. Note that any middleware from `server/index.tsx` will not be run.

resolves #2 
resolves #3
causes #17 